### PR TITLE
SDL2 API support

### DIFF
--- a/AnimationInfo.h
+++ b/AnimationInfo.h
@@ -27,6 +27,10 @@
 #include <SDL.h>
 #include <string.h>
 
+#if defined(USE_SMPEG) && SDL_VERSION_ATLEAST(2, 0, 0)
+#include <smpeg.h>
+#endif
+
 #ifndef _SDL_pixels_h
 #define SDL_PIXELFORMAT_RGB565 0
 #define SDL_PIXELFORMAT_ABGR8888 1
@@ -159,7 +163,11 @@ public:
     void setImage(SDL_Surface* surface, Uint32 texture_format);
     unsigned char getAlpha(int x, int y);
 
+#if defined(USE_SMPEG) && SDL_VERSION_ATLEAST(2, 0, 0)
+    void convertFromYUV(SMPEG_Frame* src);
+#elif defined(USE_SMPEG) && !SDL_VERSION_ATLEAST(2, 0, 0)
     void convertFromYUV(SDL_Overlay* src);
+#endif
     void subtract(SDL_Surface* surface, AnimationInfo* layer_info, unsigned char* layer_alpha_buf);
 };
 

--- a/LUAHandler.cpp
+++ b/LUAHandler.cpp
@@ -303,7 +303,11 @@ int NSGetClick(lua_State* state)
     else
         lua_pushboolean(state, false);
 
-#if SDL_VERSION_ATLEAST(1, 2, 5)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    if (bs.event_type == SDL_MOUSEWHEEL)
+        lua_pushinteger(state, bs.wheel_y);
+    else
+#elif SDL_VERSION_ATLEAST(1, 2, 5)
     if (bs.event_button == SDL_BUTTON_WHEELUP)
         lua_pushinteger(state, 1);
     else if (bs.event_button == SDL_BUTTON_WHEELDOWN)

--- a/ONScripter.h
+++ b/ONScripter.h
@@ -65,6 +65,9 @@ public:
         unsigned int event_type;
         unsigned char event_button;
         int x, y, button;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+        int wheel_x, wheel_y;
+#endif
         char str[16];
         bool down_flag;
     };
@@ -407,7 +410,9 @@ private:
     void resetSentenceFont();
     void flush(int refresh_mode, SDL_Rect* rect = NULL, bool clear_dirty_flag = true, bool direct_flag = false);
     void flushDirect(SDL_Rect& rect, int refresh_mode);
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
     void flushDirectYUV(SDL_Overlay* overlay);
+#endif
     void mouseOverCheck(int x, int y);
 
 public:
@@ -526,6 +531,9 @@ private:
     bool trapHandler();
     bool mouseMoveEvent(SDL_MouseMotionEvent* event);
     bool mousePressEvent(SDL_MouseButtonEvent* event);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    bool mouseWheelEvent(SDL_MouseWheelEvent* event);
+#endif
     void variableEditMode(SDL_KeyboardEvent* event);
     void shiftCursorOnButton(int diff);
     bool keyDownEvent(SDL_KeyboardEvent* event);
@@ -562,8 +570,10 @@ private:
     };
     int refresh_shadow_text_mode;
 
-#ifdef USE_SDL_RENDERER
+#if defined(USE_SDL_RENDERER) || SDL_VERSION_ATLEAST(2, 0, 0)
     SDL_Window* window;
+#endif
+#ifdef USE_SDL_RENDERER
     SDL_Renderer* renderer;
     SDL_Texture* texture;
 #endif
@@ -688,7 +698,9 @@ private:
     unsigned char* layer_alpha_buf; // alpha component of (movie) layer
 #if defined(USE_SMPEG)
     SMPEG* layer_smpeg_sample;
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
     SMPEG_Filter layer_smpeg_filter;
+#endif
 #endif
 
     int playSound(const char* filename, int format, bool loop_flag, int channel = 0);

--- a/ONScripter_event.cpp
+++ b/ONScripter_event.cpp
@@ -96,7 +96,11 @@ extern "C" Uint32 SDLCALL bgmfadeCallback(Uint32 interval, void* param)
  * OS Dependent Input Translation
  * **************************************** */
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+SDL_Keycode transKey(SDL_Keycode key)
+#else
 SDLKey transKey(SDLKey key)
+#endif
 {
 #if defined(IPODLINUX)
     switch (key) {
@@ -161,8 +165,13 @@ SDLKey transKey(SDLKey key)
     return key;
 }
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+SDL_Keycode transJoystickButton(Uint8 button)
+#else
 SDLKey transJoystickButton(Uint8 button)
+#endif
 {
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
 #if defined(PSP)
     SDLKey button_map[] = {SDLK_ESCAPE, /* TRIANGLE */
                            SDLK_RETURN, /* CIRCLE   */
@@ -227,6 +236,7 @@ SDLKey transJoystickButton(Uint8 button)
     };
     return button_map[button];
 #endif
+#endif
     return SDLK_UNKNOWN;
 }
 
@@ -236,10 +246,17 @@ SDL_KeyboardEvent transJoystickAxis(SDL_JoyAxisEvent& jaxis)
 
     SDL_KeyboardEvent event;
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    SDL_Keycode axis_map[] = {SDLK_LEFT, /* AL-LEFT  */
+                              SDLK_RIGHT, /* AL-RIGHT */
+                              SDLK_UP, /* AL-UP    */
+                              SDLK_DOWN /* AL-DOWN  */};
+#else
     SDLKey axis_map[] = {SDLK_LEFT, /* AL-LEFT  */
                          SDLK_RIGHT, /* AL-RIGHT */
                          SDLK_UP, /* AL-UP    */
                          SDLK_DOWN /* AL-DOWN  */};
+#endif
 
     int axis = -1;
     /* rerofumi: Jan.15.2007 */
@@ -539,7 +556,7 @@ bool ONScripter::mousePressEvent(SDL_MouseButtonEvent* event)
         if (event->type == SDL_MOUSEBUTTONDOWN)
             current_button_state.down_flag = true;
     }
-#if SDL_VERSION_ATLEAST(1, 2, 5)
+#if SDL_VERSION_ATLEAST(1, 2, 5) && !SDL_VERSION_ATLEAST(2, 0, 0)
     else if (event->button == SDL_BUTTON_WHEELUP &&
              (bexec_flag ||
               (event_mode & WAIT_TEXT_MODE) ||
@@ -579,6 +596,56 @@ bool ONScripter::mousePressEvent(SDL_MouseButtonEvent* event)
     return false;
 }
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+bool ONScripter::mouseWheelEvent(SDL_MouseWheelEvent* event)
+{
+    if (variable_edit_mode) return false;
+
+    if (automode_flag) {
+        automode_flag = false;
+        return false;
+    }
+
+    current_button_state.wheel_x = event->x;
+    current_button_state.wheel_y = event->y;
+    current_button_state.down_flag = false;
+    skip_mode &= ~SKIP_NORMAL;
+
+    if ((event->y > 0) &&
+        (bexec_flag ||
+         (event_mode & WAIT_TEXT_MODE) ||
+         (usewheel_flag && event_mode & WAIT_BUTTON_MODE) ||
+         system_menu_mode == SYSTEM_LOOKBACK)) {
+        current_button_state.button = -2;
+        sprintf(current_button_state.str, "WHEELUP");
+        if (event_mode & WAIT_TEXT_MODE) system_menu_mode = SYSTEM_LOOKBACK;
+    }
+    else if ((event->y < 0) &&
+             (bexec_flag ||
+              (enable_wheeldown_advance_flag && event_mode & WAIT_TEXT_MODE) ||
+              (usewheel_flag && event_mode & WAIT_BUTTON_MODE) ||
+              system_menu_mode == SYSTEM_LOOKBACK)) {
+        if (event_mode & WAIT_TEXT_MODE)
+            current_button_state.button = 0;
+        else
+            current_button_state.button = -3;
+        sprintf(current_button_state.str, "WHEELDOWN");
+    }
+    else
+        return false;
+
+    if (event_mode & (WAIT_INPUT_MODE | WAIT_BUTTON_MODE)) {
+        if (!(event_mode & (WAIT_TEXT_MODE)))
+            skip_mode |= SKIP_TO_EOL;
+        playClickVoice();
+
+        return true;
+    }
+
+    return false;
+}
+#endif
+
 void ONScripter::variableEditMode(SDL_KeyboardEvent* event)
 {
     int i;
@@ -611,43 +678,83 @@ void ONScripter::variableEditMode(SDL_KeyboardEvent* event)
         break;
 
     case SDLK_9:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_9:
+#else
     case SDLK_KP9:
+#endif
         variable_edit_num = variable_edit_num * 10 + 9;
         break;
     case SDLK_8:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_8:
+#else
     case SDLK_KP8:
+#endif
         variable_edit_num = variable_edit_num * 10 + 8;
         break;
     case SDLK_7:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_7:
+#else
     case SDLK_KP7:
+#endif
         variable_edit_num = variable_edit_num * 10 + 7;
         break;
     case SDLK_6:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_6:
+#else
     case SDLK_KP6:
+#endif
         variable_edit_num = variable_edit_num * 10 + 6;
         break;
     case SDLK_5:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_5:
+#else
     case SDLK_KP5:
+#endif
         variable_edit_num = variable_edit_num * 10 + 5;
         break;
     case SDLK_4:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_4:
+#else
     case SDLK_KP4:
+#endif
         variable_edit_num = variable_edit_num * 10 + 4;
         break;
     case SDLK_3:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_3:
+#else
     case SDLK_KP3:
+#endif
         variable_edit_num = variable_edit_num * 10 + 3;
         break;
     case SDLK_2:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_2:
+#else
     case SDLK_KP2:
+#endif
         variable_edit_num = variable_edit_num * 10 + 2;
         break;
     case SDLK_1:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_1:
+#else
     case SDLK_KP1:
+#endif
         variable_edit_num = variable_edit_num * 10 + 1;
         break;
     case SDLK_0:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    case SDLK_KP_0:
+#else
     case SDLK_KP0:
+#endif
         variable_edit_num = variable_edit_num * 10 + 0;
         break;
 
@@ -711,9 +818,17 @@ void ONScripter::variableEditMode(SDL_KeyboardEvent* event)
     case SDLK_ESCAPE:
         if (variable_edit_mode == EDIT_SELECT_MODE) {
             variable_edit_mode = NOT_EDIT_MODE;
+#if defined(USE_SDL_RENDERER)
+            SDL_SetWindowTitle(window, DEFAULT_WM_TITLE);
+#elif !SDL_VERSION_ATLEAST(2, 0, 0)
             SDL_WM_SetCaption(DEFAULT_WM_TITLE, DEFAULT_WM_ICON);
+#endif
             SDL_Delay(100);
+#if defined(USE_SDL_RENDERER)
+            SDL_SetWindowTitle(window, wm_title_string);
+#elif !SDL_VERSION_ATLEAST(2, 0, 0)
             SDL_WM_SetCaption(wm_title_string, wm_icon_string);
+#endif
             return;
         }
         variable_edit_mode = EDIT_SELECT_MODE;
@@ -760,7 +875,11 @@ void ONScripter::variableEditMode(SDL_KeyboardEvent* event)
                 EDIT_MODE_PREFIX, var_name, p, (variable_edit_sign == 1) ? "" : "-", variable_edit_num);
     }
 
+#if defined(USE_SDL_RENDERER)
+    SDL_SetWindowTitle(window, wm_edit_string);
+#elif !SDL_VERSION_ATLEAST(2, 0, 0)
     SDL_WM_SetCaption(wm_edit_string, wm_icon_string);
+#endif
 }
 
 void ONScripter::shiftCursorOnButton(int diff)
@@ -794,7 +913,11 @@ void ONScripter::shiftCursorOnButton(int diff)
         x = x * screen_device_width / screen_width;
         y = y * screen_device_width / screen_width;
         shift_over_button = button->no;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+        SDL_WarpMouseInWindow(window, x, y);
+#else
         SDL_WarpMouse(x, y);
+#endif
     }
 }
 
@@ -808,6 +931,16 @@ bool ONScripter::keyDownEvent(SDL_KeyboardEvent* event)
         current_button_state.event_type = SDL_MOUSEBUTTONDOWN;
         current_button_state.event_button = SDL_BUTTON_LEFT;
     }
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    else if (event->keysym.sym == SDLK_LEFT) {
+        current_button_state.event_type = SDL_MOUSEWHEEL;
+        current_button_state.wheel_y = 1;
+    }
+    else if (event->keysym.sym == SDLK_RIGHT) {
+        current_button_state.event_type = SDL_MOUSEWHEEL;
+        current_button_state.wheel_y = -1;
+    }
+#else
     else if (event->keysym.sym == SDLK_LEFT) {
         current_button_state.event_type = SDL_MOUSEBUTTONDOWN;
         current_button_state.event_button = SDL_BUTTON_WHEELUP;
@@ -816,6 +949,7 @@ bool ONScripter::keyDownEvent(SDL_KeyboardEvent* event)
         current_button_state.event_type = SDL_MOUSEBUTTONDOWN;
         current_button_state.event_button = SDL_BUTTON_WHEELDOWN;
     }
+#endif
 
     switch (event->keysym.sym) {
     case SDLK_RCTRL:
@@ -855,6 +989,16 @@ void ONScripter::keyUpEvent(SDL_KeyboardEvent* event)
         current_button_state.event_type = SDL_MOUSEBUTTONUP;
         current_button_state.event_button = SDL_BUTTON_LEFT;
     }
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    else if (event->keysym.sym == SDLK_LEFT) {
+        current_button_state.event_type = SDL_MOUSEWHEEL;
+        current_button_state.wheel_y = 1;
+    }
+    else if (event->keysym.sym == SDLK_RIGHT) {
+        current_button_state.event_type = SDL_MOUSEWHEEL;
+        current_button_state.wheel_y = -1;
+    }
+#else
     else if (event->keysym.sym == SDLK_LEFT) {
         current_button_state.event_type = SDL_MOUSEBUTTONUP;
         current_button_state.event_button = SDL_BUTTON_WHEELUP;
@@ -863,6 +1007,7 @@ void ONScripter::keyUpEvent(SDL_KeyboardEvent* event)
         current_button_state.event_type = SDL_MOUSEBUTTONUP;
         current_button_state.event_button = SDL_BUTTON_WHEELDOWN;
     }
+#endif
 
     switch (event->keysym.sym) {
     case SDLK_RCTRL:
@@ -902,7 +1047,11 @@ bool ONScripter::keyPressEvent(SDL_KeyboardEvent* event)
             variable_edit_sign = 1;
             variable_edit_num = 0;
             sprintf(wm_edit_string, "%s%s", EDIT_MODE_PREFIX, EDIT_SELECT_STRING);
+#if defined(USE_SDL_RENDERER)
+            SDL_SetWindowTitle(window, wm_edit_string);
+#elif !SDL_VERSION_ATLEAST(2, 0, 0)
             SDL_WM_SetCaption(wm_edit_string, wm_icon_string);
+#endif
         }
     }
 
@@ -1315,6 +1464,13 @@ void ONScripter::runEventLoop()
             ret = mousePressEvent(&event.button);
             if (ret) return;
             break;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+        case SDL_MOUSEWHEEL:
+            current_button_state.event_type = event.type;
+            ret = mouseWheelEvent(&event.wheel);
+            if (ret) return;
+            break;
+#endif
 #endif
         case SDL_JOYBUTTONDOWN:
             event.key.type = SDL_KEYDOWN;
@@ -1403,6 +1559,30 @@ void ONScripter::runEventLoop()
 
             return;
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+        case SDL_WINDOWEVENT:
+            switch (event.window.event) {
+            case SDL_WINDOWEVENT_LEAVE:
+                // the mouse cursor leaves the window
+                SDL_MouseMotionEvent mevent;
+                mevent.x = screen_device_width;
+                mevent.y = screen_device_height;
+                mouseMoveEvent(&mevent);
+                break;
+            case SDL_WINDOWEVENT_EXPOSED:
+#ifdef USE_SDL_RENDERER
+                SDL_RenderPresent(renderer);
+#else
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+                SDL_UpdateWindowSurface(window);
+#else
+                SDL_UpdateRect(screen_surface, 0, 0, screen_width, screen_height);
+#endif
+#endif
+                break;
+            }
+            break;
+#else
         case SDL_ACTIVEEVENT:
             if (!event.active.gain) {
                 // the mouse cursor leaves the window
@@ -1424,9 +1604,14 @@ void ONScripter::runEventLoop()
 #ifdef USE_SDL_RENDERER
             SDL_RenderPresent(renderer);
 #else
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+            SDL_UpdateWindowSurface(window);
+#else
             SDL_UpdateRect(screen_surface, 0, 0, screen_width, screen_height);
 #endif
+#endif
             break;
+#endif
 
         case SDL_QUIT:
             endCommand();

--- a/ONScripter_file2.cpp
+++ b/ONScripter_file2.cpp
@@ -348,7 +348,11 @@ int ONScripter::loadSaveFile2(int file_version)
     if (btndef_info.image_name && btndef_info.image_name[0] != '\0') {
         parseTaggedString(&btndef_info);
         setupAnimationInfo(&btndef_info);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+        SDL_SetSurfaceAlphaMod(btndef_info.image_surface, SDL_ALPHA_OPAQUE);
+#else
         SDL_SetAlpha(btndef_info.image_surface, DEFAULT_BLIT_FLAG, SDL_ALPHA_OPAQUE);
+#endif
     }
 
     if (file_version >= 202)

--- a/ONScripter_rmenu.cpp
+++ b/ONScripter_rmenu.cpp
@@ -110,7 +110,11 @@ void ONScripter::leaveSystemCall(bool restore_flag)
         if (event_mode & WAIT_BUTTON_MODE) {
             int x = shelter_mouse_state.x * screen_device_width / screen_width;
             int y = shelter_mouse_state.y * screen_device_width / screen_width;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+            SDL_WarpMouseInWindow(window, x, y);
+#else
             SDL_WarpMouse(x, y);
+#endif
         }
     }
     dirty_rect.fill(screen_width, screen_height);

--- a/ONScripter_text.cpp
+++ b/ONScripter_text.cpp
@@ -108,8 +108,13 @@ int ONScripter::drawGlyph(SDL_Surface* dst_surface, FontInfo* info, SDL_Color& c
     bool rotate_flag = false;
     if (info->getTateyokoMode() == FontInfo::TATE_MODE && IS_ROTATION_REQUIRED(text)) rotate_flag = true;
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    dst_rect.x = xy[0];
+    dst_rect.y = xy[1];
+#else
     dst_rect.x = xy[0] + minx;
     dst_rect.y = xy[1] + TTF_FontAscent((TTF_Font*)info->ttf_font[0]) - maxy;
+#endif
     if (script_h.enc.getEncoding() == Encoding::CODE_CP932)
         dst_rect.y -= (TTF_FontHeight((TTF_Font*)info->ttf_font[0]) - info->font_size_xy[1] * screen_ratio1 / screen_ratio2) / 2;
 


### PR DESCRIPTION
Adds support for SDL2 API.

Due to SDL1 not supporting new platforms or newer versions of platforms like iOS, Android, macOS, UWP/Xbox, Linux/Wayland, this aims to add support for it.

This retains backwards compatibility with compiling against SDL1 for much older platforms like Win9x, Carbon, etc.