### PR TITLE
Add an explicit return type to nscriptdecode.cpp

### DIFF
--- a/nscriptdecode.cpp
+++ b/nscriptdecode.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
-main()
+int main()
 {
     int ch;
     while ((ch = getchar()) != EOF) putchar(ch ^ 0x84);
+    return 0;
 }


### PR DESCRIPTION
Newer compilers make missing return type an error, which causes this file to not compile. So add an explicit return type in this case.